### PR TITLE
Update typedoc to version 0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ol": "5.2.0",
     "proj4": "2.4.4",
     "tsconfig-paths": "3.5.0",
-    "typedoc": "git://github.com/gberaudo/typedoc#typescript-3.1.x",
+    "typedoc": "~0.13.0",
     "typescript": "^3.1.0-dev.20180820",
     "webpack": "4.16.5",
     "webpack-cli": "3.1.0",


### PR DESCRIPTION
This version upgrade TypeScript to 3.1
See https://github.com/TypeStrong/typedoc/releases/tag/v0.13.0