### PR TITLE
Add transpiled ES Module build with microbundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /node_modules/
 /package-lock.json
 /dist/api
-/dist/main.js
+/dist/main.*
+/dist/sources.*

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-.eslintrc.yml
-.travis.yml
-tsconfig.json
-webpack.config.js
-dist/
-examples/
-*.test.js

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Geoblocks sources",
   "main": "dist/sources.js",
   "module": "dist/sources.js",
-  "source": "src/index.js",
+  "geoblocks_src": "src/index.js",
   "scripts": {
     "eslint": "eslint src/*.js",
     "eslint-fix": "eslint src/*.js --fix",

--- a/package.json
+++ b/package.json
@@ -2,18 +2,25 @@
   "name": "@geoblocks/sources",
   "version": "0.1.3",
   "description": "Geoblocks sources",
-  "module": "src/index.js",
+  "main": "dist/sources.js",
+  "module": "dist/sources.js",
+  "source": "src/index.js",
   "scripts": {
     "eslint": "eslint src/*.js",
     "eslint-fix": "eslint src/*.js --fix",
-    "build": "webpack --mode production",
-    "build-debug": "webpack --mode development",
+    "build": "microbundle --format es",
+    "build-example": "webpack --mode production",
+    "build-example-debug": "webpack --mode development",
     "start": "webpack-dev-server --mode development --content-base dist/ --watch",
     "typecheck": "tsc --pretty",
     "lint": "npm run eslint && npm run typecheck",
-    "test": "npm run lint && npm run build && npm run build-debug",
+    "test": "npm run lint && npm run build-example && npm run build-example-debug",
     "doc": "typedoc --out dist/api --theme minimal --readme none --hideGenerator --listInvalidSymbolLinks --toc none"
   },
+  "files": [
+    "/src",
+    "/dist/sources.*"
+  ],
   "author": "",
   "license": "bsd",
   "peerDependencies": {
@@ -28,6 +35,7 @@
     "@types/proj4": "^2.3.4",
     "eslint": "5.9.0",
     "eslint-config-openlayers": "11.0.0",
+    "microbundle": "^0.9.0",
     "ol": "^5.2.0",
     "proj4": "2.5.0",
     "tsconfig-paths": "3.7.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "webpack-dev-server --mode development --content-base dist/ --watch",
     "typecheck": "tsc --pretty",
     "lint": "npm run eslint && npm run typecheck",
-    "test": "npm run lint && npm run build-example && npm run build-example-debug",
+    "test": "npm run lint && npm run build && npm run build-example && npm run build-example-debug",
     "doc": "typedoc --out dist/api --theme minimal --readme none --hideGenerator --listInvalidSymbolLinks --toc none"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
   "author": "",
   "license": "bsd",
   "peerDependencies": {
-    "@geoblocks/proj": "^0.3.0",
+    "@geoblocks/proj": "^0.4.0",
     "ol": "^5.2.0",
     "proj4": "^2.4.4"
   },
   "devDependencies": {
     "@geoblocks/base": "^0.1.1",
-    "@geoblocks/proj": "^0.3.0",
+    "@geoblocks/proj": "^0.4.0",
     "@types/ol": "^4.6.2",
     "@types/proj4": "^2.3.4",
     "eslint": "5.9.0",

--- a/src/Swisstopo.js
+++ b/src/Swisstopo.js
@@ -1,7 +1,6 @@
 import olSourceWMTS from 'ol/source/WMTS.js';
 import olTilegridWMTS from 'ol/tilegrid/WMTS.js';
-import EPSG_2056 from '@geoblocks/proj/src/EPSG_2056.js';
-import EPSG_21781 from '@geoblocks/proj/src/EPSG_21781.js';
+import {EPSG_2056, EPSG_21781} from '@geoblocks/proj';
 
 
 /**
@@ -44,8 +43,8 @@ export const createSwisstopoMatrixSet = function(level) {
  * Extents of Swiss projections.
  */
 const extents = {
-  [EPSG_2056]: [2420000, 1030000, 2900000, 1350000],
-  [EPSG_21781]: [420000, 30000, 900000, 350000]
+  [EPSG_2056.code]: [2420000, 1030000, 2900000, 1350000],
+  [EPSG_21781.code]: [420000, 30000, 900000, 350000]
 };
 
 /**
@@ -76,9 +75,9 @@ function createUrl(baseUrl, projection, format) {
     return baseUrl;
   }
   let url = `${baseUrl}/1.0.0/{Layer}/default/{Time}`;
-  if (projection === EPSG_2056) {
+  if (projection === EPSG_2056.code) {
     url += `/2056/{TileMatrix}/{TileCol}/{TileRow}.${format}`;
-  } else if (projection === EPSG_21781) {
+  } else if (projection === EPSG_21781.code) {
     url += `/21781/{TileMatrix}/{TileRow}/{TileCol}.${format}`;
   } else {
     throw new Error(`Unsupported projection ${projection}`);
@@ -112,7 +111,7 @@ export default class SwisstopoSource extends olSourceWMTS {
   constructor(options) {
     const format = options.format || 'image/png';
     const projection = options.projection;
-    console.assert(projection === EPSG_21781 || projection === EPSG_2056);
+    console.assert(projection === EPSG_21781.code || projection === EPSG_2056.code);
     const tilegrid = createTileGrid(projection, options.level || 27);
     const projectionCode = projection.split(':')[1];
     const extension = format.split('/')[1];

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,3 @@
+import Swisstopo from './Swisstopo';
+
+export {Swisstopo};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   entry: './examples/swisstopo.js',
   devtool: 'source-map',
+  resolve: {symlinks: false},
   output: {
     filename: 'main.js'
   }


### PR DESCRIPTION
- Add module entrypoint (`index.js`)
- Use whitelist of files (`/src`, `/dist/sources.*`) instead of `.npmignore`
- Add build target using microbundle and rename existing example builds

See https://github.com/geoblocks/base/issues/4